### PR TITLE
Added 'overwriteSrc' option which can be used in multiple ways.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -68,9 +68,45 @@ module.exports = function(grunt) {
                 options: {
                     compress: true
                 }
+            },
+            "no-destination": {
+                expand: true,
+                nonull: true,
+                cwd: 'tmp/no-destination',
+                src: 'component.ts',
+                options: {
+                    overwriteSrc: true
+                }
+            },
+            "multi-src": {
+                expand: true,
+                nonull: true,
+                cwd: 'tmp/multi-src',
+                src: '*.ts',
+                options: {
+                    overwriteSrc: true
+                }
             }
         },
 
+        copy: {
+            "no-destination": {
+                src: [
+                    'test/fixtures/component.ts',
+                    'test/fixtures/component.html',
+                    'test/fixtures/component.css',
+                ],
+                flatten: true,
+                expand: true,
+                dest: 'tmp/no-destination/'
+            },
+            "multi-src": {
+                src: 'test/fixtures/*',
+                flatten: true,
+                expand: true,
+                dest: 'tmp/multi-src/'
+            }
+        },
         // Unit tests.
         nodeunit: {
             tests: ['test/*_test.js']
@@ -85,10 +121,11 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-contrib-jshint');
     grunt.loadNpmTasks('grunt-contrib-clean');
     grunt.loadNpmTasks('grunt-contrib-nodeunit');
+    grunt.loadNpmTasks('grunt-contrib-copy');
 
     // Whenever the "test" task is run, first clean the "tmp" dir, then run this
     // plugin's task(s), then test the result.
-    grunt.registerTask('test', ['clean', 'ng2_inline', 'nodeunit']);
+    grunt.registerTask('test', ['clean', 'copy', 'ng2_inline', 'nodeunit']);
 
     // By default, lint and run all tests.
     grunt.registerTask('default', ['jshint', 'test']);

--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ Default value: `false`
 
 Set base folder for templates and stylesheet relative to source file.
 
+#### options.overwriteSrc
+Type: `Boolean`  
+Default value: `false`
+
+When this option is set to `true`, the source files will be replaced with files having inline templates and css.
+`dest` provided with this task will be ignored.
+
 ### Usage Examples
 
 ```js
@@ -69,6 +76,25 @@ grunt.initConfig({
                 base: 'src/assets',
                 compress: true,
                 relative: false
+            }
+        }
+    }
+});
+```
+
+```js
+grunt.initConfig({
+    ng2_inline: {
+        default: {
+            expand: true,
+            nonull: true,
+            cwd: 'src',
+            src: 'app/**/*.ts',
+            options: {
+                base: 'src/assets',
+                compress: true,
+                relative: false,
+                overwriteSrc: true
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -28,10 +28,11 @@
     "angular2-inline-template-style": "0.2.1"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "1.0.0",
+    "grunt": "1.0.0",
     "grunt-contrib-clean": "1.0.0",
-    "grunt-contrib-nodeunit": "1.0.0",
-    "grunt": "1.0.0"
+    "grunt-contrib-copy": "^1.0.0",
+    "grunt-contrib-jshint": "1.0.0",
+    "grunt-contrib-nodeunit": "1.0.0"
   },
   "keywords": [
     "gruntplugin"

--- a/tasks/ng2_inline.js
+++ b/tasks/ng2_inline.js
@@ -8,9 +8,9 @@
 
 'use strict';
 
-module.exports = function(grunt) {
+module.exports = function (grunt) {
 
-    grunt.registerMultiTask('ng2_inline', 'Inline angular2 templates and styles with Grunt and angular2-inline-template-style', function() {
+    grunt.registerMultiTask('ng2_inline', 'Inline angular2 templates and styles with Grunt and angular2-inline-template-style', function () {
 
         var ng2Inline = require('angular2-inline-template-style'),
             path = require('path');
@@ -19,18 +19,19 @@ module.exports = function(grunt) {
         var options = this.options({
             base: this.data.cwd,
             compress: false,
-            relative: false
+            relative: false,
+            overwriteSrc: false
         });
         grunt.log.debug('Options: ', options);
 
 
         // Iterate over all specified file groups.
-        this.files.forEach(function(file) {
+        this.files.forEach(function (file) {
 
             file.src
                 .filter(
                     // Fail on invalid source files (if nonull was set).
-                    function(filepath) {
+                    function (filepath) {
                         if (!grunt.file.exists(filepath)) {
                             grunt.fail.warn('Source file "' + filepath + '" not found.');
                             return false;
@@ -40,18 +41,25 @@ module.exports = function(grunt) {
                     }
                 )
                 .forEach(
-                    function(filepath) {
+                    function (filepath) {
                         grunt.log.debug('Process file: ' + filepath);
-                        
+
                         // Read source file.
                         var content = grunt.file.read(filepath);
-                        
+
                         // Do inline!
                         content = ng2Inline(content, options, path.dirname(filepath));
-                        
-                        // Write the destination file.
-                        grunt.log.debug('Write to: ' + file.dest);
-                        grunt.file.write(file.dest, content);
+
+                        if (!options.overwriteSrc) {
+                            // Write the destination file.
+                            grunt.log.debug('Write to: ' + file.dest);
+                            grunt.file.write(file.dest, content);
+
+                        } else {
+                            //If a destination file is not specified, this will overrite the
+                            //original file that had templateUrl with the one having inline template.
+                            grunt.file.write(filepath, content);
+                        }
                     }
                 );
         });

--- a/test/expected/second-component.ts
+++ b/test/expected/second-component.ts
@@ -1,0 +1,10 @@
+import {Component} from 'angular2/core';
+
+@Component({
+    selector: 'foo',
+    template: '<h1>Hello World From Second Component</h1>',
+    styles: ['h1 {    color: #ff0000;}div {    width: 100%;}']
+})
+export class SecondComponent {
+    constructor() { }
+}

--- a/test/fixtures/second-component.css
+++ b/test/fixtures/second-component.css
@@ -1,0 +1,6 @@
+h1 {
+    color: #ff0000;
+}
+div {
+    width: 100%;
+}

--- a/test/fixtures/second-component.html
+++ b/test/fixtures/second-component.html
@@ -1,0 +1,1 @@
+<h1>Hello World From Second Component</h1>

--- a/test/fixtures/second-component.ts
+++ b/test/fixtures/second-component.ts
@@ -1,0 +1,10 @@
+import {Component} from 'angular2/core';
+
+@Component({
+    selector: 'foo',
+    templateUrl: 'second-component.html',
+    styleUrls: ['second-component.css']
+})
+export class SecondComponent {
+    constructor() { }
+}

--- a/test/ng2_inline_test.js
+++ b/test/ng2_inline_test.js
@@ -47,6 +47,30 @@ exports.ng2_inline = {
         test.equal(actual, expected, 'should inline compressed template and style into component file.');
 
         test.done();
+    },
+
+    noDestination: function(test) {
+        test.expect(1);
+
+        var actual = grunt.file.read('tmp/no-destination/component.ts');
+        var expected = grunt.file.read('test/expected/component.ts');
+        test.equal(actual, expected, 'should overrite the original src file with inlined css and html.');
+
+        test.done();
+    },
+
+    multiSrc: function(test) {
+        test.expect(2);
+
+        var actual = grunt.file.read('tmp/multi-src/component.ts');
+        var expected = grunt.file.read('test/expected/component.ts');
+        test.equal(actual, expected, 'should overrite the original src file with inlined css and html.');
+
+        var actual2 = grunt.file.read('tmp/multi-src/second-component.ts');
+        var expected2 = grunt.file.read('test/expected/second-component.ts');
+        test.equal(actual2, expected2, 'should overrite the original src file with inlined css and html.');
+
+        test.done();
     }
 
 };


### PR DESCRIPTION
- It can be used to inline multiple files at once.
- It doesn't need a 'dest' property. This option will replace the original source file with the new inlined file.