### PR TITLE
update angular2-inline-template-style version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "angular2-inline-template-style": "1.0.0"
+    "angular2-inline-template-style": "1.2.0"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "1.0.0",


### PR DESCRIPTION
version updated to 1.2.0 that ignores commented out templateUrl and styleUrl lines and other fixes